### PR TITLE
ci: add comprehensive CI pipeline and pre-commit hooks

### DIFF
--- a/.agent/workflows/build.md
+++ b/.agent/workflows/build.md
@@ -16,6 +16,7 @@ Use this workflow to execute a structured implementation plan step-by-step.
 1. **Setup**
    - Read the implementation plan from `docs/plans/`.
    - Ensure you are in the correct context (checkout branch if needed).
+   - Run `npm run check` to verify clean starting state.
 
 2. **Task Execution (Round-robin per task)**
    - For each task in the plan:
@@ -38,5 +39,18 @@ Use this workflow to execute a structured implementation plan step-by-step.
 5. **Progress Tracking**
    - Check off tasks in the plan file as they are completed.
    - Update `PROJECT_HISTORY.md` at the end of the session.
+
+6. **Continuous Verification**
+   - Run `npm run check` after each task to catch regressions early.
+   - Pre-commit hooks will run automatically on commit (type check, lint, tests).
+   - If pre-commit fails, fix before proceeding.
+
+**Test Commands:**
+| Command | When to Use |
+|---------|-------------|
+| `npm run check` | Quick validation after each task (~15s) |
+| `npm run check:full` | Full validation including Python (~20s) |
+| `npm test -- --watch` | TDD mode for frontend |
+| `npm run test:py` | Python unit tests only |
 
 **Next Step**: Once all tasks are complete, use `/code-review` for the final quality check.

--- a/.agent/workflows/closeout.md
+++ b/.agent/workflows/closeout.md
@@ -14,7 +14,11 @@ Use this workflow to wrap up a development session and maintain a clean project 
 
 ## The Process
 1. **Verification**
-   - Run ALL tests in the project to ensure no regressions.
+   - Run `npm run check:full` to execute all automated checks:
+     - TypeScript type checking
+     - ESLint
+     - Jest tests (15 frontend tests)
+     - pytest (37 Python unit tests)
    - Verify `CLAUDE.md` is updated if any new patterns were established.
 
 2. **Improvement (Kaizen)**
@@ -34,6 +38,8 @@ Use this workflow to wrap up a development session and maintain a clean project 
 4. **Git Hygiene**
    - Stage any remaining changes.
    - Commit with a descriptive message if not already done.
+   - Pre-commit hooks will run automatically (type check, lint, tests).
+   - If pre-commit fails, fix issues before retrying commit.
    - Push to the remote branch.
    - (Optional) Clean up local worktrees.
 

--- a/.agent/workflows/code-review.md
+++ b/.agent/workflows/code-review.md
@@ -27,10 +27,31 @@ Use this workflow to ensure high-quality, spec-compliant code before merging.
   - Suggest corrections aligned with established system
 
 ## The Process
-1. Inspect the diff of the changes.
-2. Run the test suite on the modified files.
-3. If issues are found, provide specific feedback or implement the fixes.
-4. Once satisfied, approve the changes for closeout.
+1. **Automated Checks First**
+   - Run `npm run check:full` to execute all automated checks.
+   - This runs: TypeScript, ESLint, Jest (15 tests), pytest (37 tests).
+   - If any fail, fix before proceeding.
+
+2. **Inspect the diff** of the changes.
+
+3. **Manual Review** for items automation can't catch:
+   - Business logic correctness
+   - Architecture decisions
+   - Security implications
+
+4. If issues are found, provide specific feedback or implement the fixes.
+
+5. Once satisfied, approve the changes for closeout.
+
+## CI Pipeline
+
+The CI pipeline (`.github/workflows/ci.yml`) runs automatically on PRs:
+- `lint-and-typecheck` - ESLint + TypeScript
+- `test-frontend` - Jest tests with coverage
+- `test-python` - pytest unit tests with coverage
+- `validate-yaml` - YAML syntax validation
+
+All jobs must pass before merge. The `ci-success` job gates PRs.
 
 ## Production Reliability Checklist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  test-frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest tests
+        run: npm test -- --ci --coverage
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-coverage
+          path: coverage/
+          retention-days: 7
+
+  test-python:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest-cov
+
+      - name: Run pytest (unit tests)
+        run: |
+          pytest tests/ -v --tb=short --cov=scripts --cov-report=xml --cov-report=term-missing \
+            --ignore=tests/test_integration.py \
+            --ignore=tests/test_shopping_api.py \
+            --ignore=tests/test_api_perf.py
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: python-coverage
+          path: coverage.xml
+          retention-days: 7
+
+  validate-yaml:
+    name: YAML Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate YAML syntax
+        run: python3 scripts/validate_yaml.py
+
+  # Summary job that depends on all others - useful for branch protection
+  ci-success:
+    name: CI Success
+    needs: [lint-and-typecheck, test-frontend, test-python, validate-yaml]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ needs.lint-and-typecheck.result }}" != "success" ]] || \
+             [[ "${{ needs.test-frontend.result }}" != "success" ]] || \
+             [[ "${{ needs.test-python.result }}" != "success" ]] || \
+             [[ "${{ needs.validate-yaml.result }}" != "success" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi
+          echo "All CI checks passed!"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Fast pre-commit checks
+# Runs type checking, linting, and tests before allowing commit
+
+echo "Running pre-commit checks..."
+
+# Type check (fast, catches most errors)
+echo "→ Type checking..."
+npx tsc --noEmit
+if [ $? -ne 0 ]; then
+    echo "✗ Type check failed. Fix errors before committing."
+    exit 1
+fi
+
+# Lint (quiet mode - only errors, no warnings)
+echo "→ Linting..."
+npm run lint --quiet
+if [ $? -ne 0 ]; then
+    echo "✗ Lint failed. Fix errors before committing."
+    exit 1
+fi
+
+# Run frontend tests (bail on first failure for speed)
+echo "→ Running frontend tests..."
+npm test -- --bail --passWithNoTests
+if [ $? -ne 0 ]; then
+    echo "✗ Frontend tests failed. Fix before committing."
+    exit 1
+fi
+
+# Run Python tests (unit tests only, stop on first failure for speed)
+echo "→ Running Python tests..."
+if [ -d ".venv" ]; then
+    PYTHONPATH=. .venv/bin/pytest tests/ -x --tb=line -q \
+        --ignore=tests/test_integration.py \
+        --ignore=tests/test_shopping_api.py \
+        --ignore=tests/test_api_perf.py
+else
+    PYTHONPATH=. python3 -m pytest tests/ -x --tb=line -q \
+        --ignore=tests/test_integration.py \
+        --ignore=tests/test_shopping_api.py \
+        --ignore=tests/test_api_perf.py
+fi
+if [ $? -ne 0 ]; then
+    echo "✗ Python tests failed. Fix before committing."
+    exit 1
+fi
+
+echo "✓ All pre-commit checks passed!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,41 @@ If blocked, explain which constraint failed:
 
 NEVER proceed with invalid plan. Ask for guidance.
 
+## Testing & CI
+
+**Automated Testing:**
+- **Pre-commit hooks**: Run automatically on every commit (type check, lint, tests)
+- **CI Pipeline**: Runs on all PRs with parallel jobs
+
+**Quick Commands:**
+| Command | Purpose | Speed |
+|---------|---------|-------|
+| `npm run check` | Fast local validation (TS + lint + Jest) | ~15s |
+| `npm run check:full` | Full check including Python tests | ~20s |
+| `npm run test:py` | Python unit tests only | ~3s |
+| `npm run test:py:all` | All Python tests (including integration) | ~5s |
+
+**CI Jobs (parallel):**
+1. `lint-and-typecheck` - ESLint + TypeScript
+2. `test-frontend` - Jest (15 tests)
+3. `test-python` - pytest (37 unit tests)
+4. `validate-yaml` - YAML syntax validation
+
+**Pre-commit Hook:**
+Runs before every commit:
+```
+→ Type checking...
+→ Linting...
+→ Frontend tests...
+→ Python tests...
+✓ All pre-commit checks passed!
+```
+
+**Test Organization:**
+- Unit tests: `tests/test_*.py` (run in CI)
+- Integration tests: `test_integration.py`, `test_shopping_api.py`, `test_api_perf.py` (require Supabase, run locally with `npm run test:py:all`)
+- Frontend tests: `src/components/__tests__/*.test.tsx`
+
 ## Engineering Standards
 
 **Dependency Management:**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,7 @@ const eslintConfig = [
     },
   },
   {
-    ignores: [".next/", "next-env.d.ts", "coverage/"],
+    ignores: [".next/", "next-env.d.ts", "coverage/", "skills/"],
   },
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,14 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
+        "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "concurrently": "^8.2.2",
         "eslint": "^9",
         "eslint-config-next": "^15.1.0",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "tailwindcss": "^4",
@@ -1499,6 +1501,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1560,6 +1572,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1574,6 +1596,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -2660,6 +2706,237 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -6146,6 +6423,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iceberg-js": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,12 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:py": "PYTHONPATH=. .venv/bin/pytest tests/ -v --tb=short --ignore=tests/test_integration.py --ignore=tests/test_shopping_api.py --ignore=tests/test_api_perf.py",
+    "test:py:all": "PYTHONPATH=. .venv/bin/pytest tests/ -v --tb=short",
+    "check": "tsc --noEmit && npm run lint -- --quiet && npm test -- --bail --passWithNoTests",
+    "check:full": "npm run check && npm run test:py",
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
@@ -28,12 +33,14 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "concurrently": "^8.2.2",
     "eslint": "^9",
     "eslint-config-next": "^15.1.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "tailwindcss": "^4",


### PR DESCRIPTION
- Add CI workflow with parallel jobs for lint, type-check, frontend tests, Python tests, and YAML validation
- Set up Husky pre-commit hooks for fast local validation
- Add npm scripts: check, check:full, test:py, test:py:all
- Exclude integration tests (requiring Supabase) from CI/pre-commit
- Add @types/jest for TypeScript test support
- Exclude skills/ directory from ESLint (agent definitions, not app code)

https://claude.ai/code/session_01L7sC8qh6LxLt2Aj1JGdzkx